### PR TITLE
Fix webpack jsonp charset issue

### DIFF
--- a/EncodingPlugin.js
+++ b/EncodingPlugin.js
@@ -16,10 +16,20 @@ class EncodingPlugin {
     }
 
     apply(compiler) {
-        const { options } = this;
+        const { options, constructor: { name: pluginName } } = this;
         const matchFileName = ModuleFilenameHelpers.matchObject.bind(undefined, options);
 
-        compiler.hooks.emit.tapAsync('EncodingPlugin', ({ assets, errors }, callback) => {
+        compiler.hooks.compilation.tap(
+            pluginName, compilation => {
+                const { jsonpScript } = compilation.mainTemplate.hooks;
+                if (jsonpScript) {
+                    jsonpScript.tap(pluginName, s => s.replace(/["']utf-8["']/gi, `"${options.encoding}"`));
+                }
+                return compilation;
+            }
+        );
+
+        compiler.hooks.emit.tapAsync(pluginName, ({ assets, errors }, callback) => {
             Object.keys(assets).filter(matchFileName).forEach(file => {
                 const asset = assets[file];
                 let source;
@@ -45,7 +55,7 @@ class EncodingPlugin {
                         new SourceMapSource(encodedSource, file, map) :
                         new RawSource(encodedSource);
                 } catch (e) {
-                    errors.push(new Error(`${file} from EncodingPlugin: ${e.message}`));
+                    errors.push(new Error(`${file} from ${pluginName}: ${e.message}`));
                 }
             });
 

--- a/EncodingPlugin.js
+++ b/EncodingPlugin.js
@@ -23,7 +23,7 @@ class EncodingPlugin {
             pluginName, compilation => {
                 const { jsonpScript } = compilation.mainTemplate.hooks;
                 if (jsonpScript) {
-                    jsonpScript.tap(pluginName, s => s.replace(/["']utf-8["']/gi, `"${options.encoding}"`));
+                    jsonpScript.tap(pluginName, s => s.replace(/(["'])utf-8["']/gi, `$1${options.encoding}$1`));
                 }
                 return compilation;
             }

--- a/EncodingPlugin.js
+++ b/EncodingPlugin.js
@@ -21,10 +21,12 @@ class EncodingPlugin {
 
         compiler.hooks.compilation.tap(
             pluginName, compilation => {
-                const { jsonpScript } = compilation.mainTemplate.hooks;
-                if (jsonpScript) {
-                    jsonpScript.tap(pluginName, s => s.replace(/(["'])utf-8["']/gi, `$1${options.encoding}$1`));
-                }
+                ['jsonpScript', 'hotBootstrap'].forEach(id => {
+                    const hook = compilation.mainTemplate.hooks[id];
+                    if (hook) {
+                        hook.tap(pluginName, s => s.replace(/(["'])utf-8["']/gi, `$1${options.encoding}$1`));
+                    }
+                });
                 return compilation;
             }
         );


### PR DESCRIPTION
webpack/webpack#8521
A little bit hacky, but seems like bulletproof.

When doing the dynamic import() call, async chunks injected with charset="utf-8" attribute. But assets are emitted in another encoding via webpack-encoding-plugin. This attribute is hardcoded and there no way to configure this.

This PR fixes that by replacing "utf-8" strings with actual encoding (only in webpack JSONP runtime). There no additional configuration needed.